### PR TITLE
Fix packaging in ESM environment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,3 +21,5 @@ jobs:
       - run: npm run format:check
       - run: npm run lint
       - run: npm run test
+      - name: Check ESM module resolution
+        run: npx @arethetypeswrong/cli --ignore-rules cjs-resolves-to-esm --pack

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ If you are viewing the README on NPM, refer to [GitHub README](https://github.co
 ## Install
 
 This package is [ESM only][esm].
-In Node.js (version 16+), install with [npm][]:
+In Node.js (version 16+), install with [npm]:
 
 ```sh
 npm install remark-github-beta-blockquote-admonitions

--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@ remark plugin to add support for [GitHub beta blockquote-based admonitions](http
 
 If you are viewing the README on NPM, refer to [GitHub README](https://github.com/myl7/remark-github-beta-blockquote-admonitions#readme) for possible documentation update
 
+## Install
+
+This package is [ESM only][esm].
+In Node.js (version 16+), install with [npm][]:
+
+```sh
+npm install remark-github-beta-blockquote-admonitions
+```
+
+[esm]: https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c
+[npm]: https://docs.npmjs.com/cli/install
+
 ## Get Started
 
 ```js

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "remark-github-beta-blockquote-admonitions",
   "version": "2.1.1",
   "description": "remark plugin to add support for GitHub beta blockquote-based admonitions",
-  "main": "dist/index.js",
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
     "test": "mocha",
@@ -31,7 +30,13 @@
   "files": [
     "dist"
   ],
-  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "dependencies": {
     "unist-util-visit": "^4.1.2"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import type { BuildVisitor } from 'unist-util-visit'
 import type { Plugin } from 'unified'
 import type { Blockquote, Paragraph, Text } from 'mdast'
 
-import { handleNode as handleNodeWithLegacyTitle } from './legacyTitle'
+import { handleNode as handleNodeWithLegacyTitle } from './legacyTitle.js'
 import {
   nameFilter,
   classNameMap,
@@ -14,10 +14,10 @@ import {
   ConfigForLegacyTitle,
   defaultConfig,
   defaultConfigForLegacyTitle,
-} from './config'
+} from './config.js'
 
 export { Config, ConfigForLegacyTitle, defaultConfig, defaultConfigForLegacyTitle }
-export { mkdocsConfig as mkdocsConfigForLegacyTitle } from './legacyTitle'
+export { mkdocsConfig as mkdocsConfigForLegacyTitle } from './legacyTitle.js'
 
 const plugin: Plugin = function (providedConfig?: Partial<Config | ConfigForLegacyTitle>) {
   const legacyTitle = providedConfig?.legacyTitle ?? defaultConfig.legacyTitle

--- a/src/legacyTitle.ts
+++ b/src/legacyTitle.ts
@@ -4,7 +4,7 @@
 import type { BuildVisitor } from 'unist-util-visit'
 import type { Blockquote, Paragraph, Text } from 'mdast'
 
-import { ConfigForLegacyTitle as Config, classNameMap, nameFilter } from './config'
+import { ConfigForLegacyTitle as Config, classNameMap, nameFilter } from './config.js'
 
 export const handleNode =
   (config: Config): BuildVisitor =>

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -8,7 +8,7 @@ import { remark } from 'remark'
 import remarkParse from 'remark-parse'
 import remarkRehype from 'remark-rehype'
 import rehypeStringify from 'rehype-stringify'
-import plugin, { Config, mkdocsConfig } from '../src'
+import plugin, { Config, mkdocsConfig } from '../src/index.js'
 
 async function mdToHtml(md: string, options?: Partial<Config>) {
   return String(await remark().use(remarkParse).use(plugin, options).use(remarkRehype).use(rehypeStringify).process(md))

--- a/test/legacyTitle.spec.ts
+++ b/test/legacyTitle.spec.ts
@@ -8,7 +8,7 @@ import { remark } from 'remark'
 import remarkParse from 'remark-parse'
 import remarkRehype from 'remark-rehype'
 import rehypeStringify from 'rehype-stringify'
-import plugin, { ConfigForLegacyTitle as Config, mkdocsConfigForLegacyTitle as mkdocsConfig } from '../src'
+import plugin, { ConfigForLegacyTitle as Config, mkdocsConfigForLegacyTitle as mkdocsConfig } from '../src/index.js'
 
 async function mdToHtml(md: string, options?: Partial<Config>) {
   const optionsForLegacyTitle = { ...options, legacyTitle: true }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "include": ["src", "test"],
   "compilerOptions": {
     "lib": ["es2021"],
-    "module": "Node16",
+    "module": "node16",
     "target": "es2021",
     "strict": true,
     "skipLibCheck": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,13 +5,12 @@
     "module": "es2022",
     "target": "es2021",
     "strict": true,
-    "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "outDir": "dist",
     "declaration": true,
     "declarationDir": "dist",
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "downlevelIteration": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "include": ["src", "test"],
   "compilerOptions": {
     "lib": ["es2021"],
-    "module": "es2022",
+    "module": "Node16",
     "target": "es2021",
     "strict": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Hello 👋🏽 

This package cannot be imported in ESM environment even it says it should work in `package.json`.
For example, if the downstream consumer has `type: "module"` in their `package.json`, the import will fail with `ERR_MODULE_NOT_FOUND` when the entry tries to resolve internal modules:

<img width="1440" alt="image" src="https://github.com/myl7/remark-github-beta-blockquote-admonitions/assets/6838982/ad093f20-e74b-4835-920d-fb3df11809d4">

This can be solved by adding `.js` suffix to the import path and specify `moduleResolution` to `node16` in tsconfig to enforce this rule.

I am also adding a ESM-only warning in the README, copied from https://github.com/remarkjs/remark-directive because it seems the remark plugin ecosystem is pretty much ESM-only now.
But I am not sure if this package will work in deno or in the browser, through esm.sh so I didn't copy those instruction over.

After the change, the build passes [arethetypeswrong] check.

[arethetypeswrong]: https://arethetypeswrong.github.io

| Before | After |
| --- |  --- |
| ![Screenshot 2023-10-19 at 12-27-18 Are The Types Wrong](https://github.com/myl7/remark-github-beta-blockquote-admonitions/assets/6838982/cab1a580-a102-4ee2-9989-24d3a47f70f3) | ![image](https://github.com/myl7/remark-github-beta-blockquote-admonitions/assets/6838982/e132e66a-7178-4e73-8515-fb2b040048be) |

Some reference reading for this ESM issue:

- https://blog.isquaredsoftware.com/2023/08/esm-modernization-lessons/
- https://www.typescriptlang.org/docs/handbook/modules/reference.html#node16-nodenext-1
- https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c

