### PR TITLE
Add snapshot testing on all test cases

### DIFF
--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -1,0 +1,154 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`GitHub beta blockquote-based admonitions with titles like [!NOTE] > should not transform when single line 1`] = `
+"<h1>Admonitions</h1>
+<blockquote>
+<p>[!NOTE] test</p>
+</blockquote>"
+`;
+
+exports[`GitHub beta blockquote-based admonitions with titles like [!NOTE] > should not transform when title is not in form [!NOTE] but legacy **Note** 1`] = `
+"<h1>Admonitions</h1>
+<blockquote>
+<p><strong>Note</strong>
+test</p>
+</blockquote>"
+`;
+
+exports[`GitHub beta blockquote-based admonitions with titles like [!NOTE] > should transform 1`] = `
+"<h1>Admonitions</h1>
+<div class=\\"admonition\\">
+<p class=\\"admonition-title\\">NOTE</p>
+<p>test</p>
+</div>"
+`;
+
+exports[`GitHub beta blockquote-based admonitions with titles like [!NOTE] > should transform with nested ones 1`] = `
+"<h1>Admonitions</h1>
+<div class=\\"admonition\\">
+<p class=\\"admonition-title\\">NOTE</p>
+<p>test</p>
+<div class=\\"admonition\\">
+<p class=\\"admonition-title\\">NOTE</p>
+<p>test</p>
+<div class=\\"admonition\\">
+<p class=\\"admonition-title\\">WARNING</p>
+<p>test</p>
+</div>
+</div>
+</div>"
+`;
+
+exports[`GitHub beta blockquote-based admonitions with titles like [!NOTE] > should transform with ordered lists from issue #4 1`] = `
+"<h1>Admonitions</h1>
+<div class=\\"admonition\\">
+<p class=\\"admonition-title\\">NOTE</p>
+<p></p>
+<ol>
+<li>Here you go</li>
+<li>Here you go again</li>
+<li>Here you go one more time</li>
+</ol>
+</div>"
+`;
+
+exports[`GitHub beta blockquote-based admonitions with titles like [!NOTE] > should transform with title with trailing whitespaces to be trimmed 1`] = `
+"<h1>Admonitions</h1>
+<div class=\\"admonition\\">
+<p class=\\"admonition-title\\">NOTE</p>
+<p>test</p>
+</div>"
+`;
+
+exports[`GitHub beta blockquote-based admonitions with titles like [!NOTE] > should transform with unordered lists from issue #4 1`] = `
+"<h1>Admonitions</h1>
+<div class=\\"admonition\\">
+<p class=\\"admonition-title\\">NOTE</p>
+<p></p>
+<ul>
+<li>Here you go</li>
+<li>Here you go again</li>
+<li>Here you go one more time</li>
+</ul>
+</div>"
+`;
+
+exports[`MkDocs admonition HTML options for titles like [!NOTE] > should transform 1`] = `
+"<h1>Admonitions</h1>
+<div class=\\"admonition note danger\\">
+<p class=\\"admonition-title\\">Don't try this at home</p>
+<p>You should note that the title will be automatically capitalized.</p>
+</div>"
+`;
+
+exports[`MkDocs admonition HTML options for titles like [!NOTE] > should transform with custom types 1`] = `
+"<h1>Admonitions</h1>
+<div class=\\"admonition guess\\">
+<p class=\\"admonition-title\\">Don't try this at home</p>
+<p>You should note that the title will be automatically capitalized.</p>
+</div>"
+`;
+
+exports[`the plugin options for titles like [!NOTE] > should accept custom class names 1`] = `
+"<h1>Admonitions</h1>
+<div class=\\"ad\\">
+<p class=\\"ad-title1 ad-title2\\">NOTE</p>
+<p>test</p>
+</div>"
+`;
+
+exports[`the plugin options for titles like [!NOTE] > should accept custom class names with functions 1`] = `
+"<h1>Admonitions</h1>
+<div class=\\"ad-note\\">
+<p class=\\"ad-note-title1 ad-note-title2\\">NOTE</p>
+<p>test</p>
+</div>"
+`;
+
+exports[`the plugin options for titles like [!NOTE] > should accept custom title filter 1`] = `
+"<h1>Admonitions</h1>
+<div class=\\"admonition\\">
+<p class=\\"admonition-title\\">TIPS</p>
+<p>test</p>
+</div>"
+`;
+
+exports[`the plugin options for titles like [!NOTE] > should accept custom title filter with functions 1`] = `
+"<h1>Admonitions</h1>
+<div class=\\"admonition\\">
+<p class=\\"admonition-title\\">tIps</p>
+<p>test</p>
+</div>"
+`;
+
+exports[`the plugin options for titles like [!NOTE] > should accept data maps to edit data 1`] = `
+"<h1>Admonitions</h1>
+<admonition class=\\"admonition\\">
+<p class=\\"admonition-title\\">NOTE</p>
+<p>test</p>
+</admonition>"
+`;
+
+exports[`the plugin options for titles like [!NOTE] > should accept title text map to customize title text 1`] = `
+"<h1>Admonitions</h1>
+<div class=\\"admonition\\">
+<p class=\\"admonition-title\\">OKOK</p>
+<p>test</p>
+</div>"
+`;
+
+exports[`the plugin options for titles like [!NOTE] > should accept title text map to customize title text with spaces 1`] = `
+"<h1>Admonitions</h1>
+<div class=\\"admonition\\">
+<p class=\\"admonition-title\\"> OK OK </p>
+<p>test</p>
+</div>"
+`;
+
+exports[`the plugin options for titles like [!NOTE] > should accept title with trailing whitespaces with custom whitespace handling 1`] = `
+"<h1>Admonitions</h1>
+<div class=\\"admonition\\">
+<p class=\\"admonition-title\\">NOTE</p>
+<p>test</p>
+</div>"
+`;

--- a/test/__snapshots__/legacyTitle.spec.ts.snap
+++ b/test/__snapshots__/legacyTitle.spec.ts.snap
@@ -1,0 +1,136 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`GitHub beta blockquote-based admonitions with legacy titles like **Note** > should not transform when title is not strong 1`] = `
+"<h1>Admonitions</h1>
+<blockquote>
+<p><em>Note</em>
+test</p>
+</blockquote>"
+`;
+
+exports[`GitHub beta blockquote-based admonitions with legacy titles like **Note** > should transform 1`] = `
+"<h1>Admonitions</h1>
+<blockquote class=\\"admonition\\">
+<p><strong class=\\"admonition-title\\">Note</strong>
+test</p>
+</blockquote>"
+`;
+
+exports[`GitHub beta blockquote-based admonitions with legacy titles like **Note** > should transform when single line 1`] = `
+"<h1>Admonitions</h1>
+<blockquote class=\\"admonition\\">
+<p><strong class=\\"admonition-title\\">Note</strong> test</p>
+</blockquote>"
+`;
+
+exports[`GitHub beta blockquote-based admonitions with legacy titles like **Note** > should transform with nested ones 1`] = `
+"<h1>Admonitions</h1>
+<blockquote class=\\"admonition\\">
+<p><strong class=\\"admonition-title\\">Note</strong>
+test</p>
+<blockquote class=\\"admonition\\">
+<p><strong class=\\"admonition-title\\">Note</strong>
+test</p>
+<blockquote class=\\"admonition\\">
+<p><strong class=\\"admonition-title\\">Warning</strong>
+test</p>
+</blockquote>
+</blockquote>
+</blockquote>"
+`;
+
+exports[`MkDocs admonition HTML options for legacy titles like **Note** > should transform 1`] = `
+"<h1>Admonitions</h1>
+<div class=\\"admonition note danger\\">
+<p class=\\"admonition-title\\">Don't try this at home</p>
+<p>You should note that the title will be automatically capitalized.</p>
+</div>"
+`;
+
+exports[`MkDocs admonition HTML options for legacy titles like **Note** > should transform with custom types 1`] = `
+"<h1>Admonitions</h1>
+<div class=\\"admonition guess\\">
+<p class=\\"admonition-title\\">Don't try this at home</p>
+<p>You should note that the title will be automatically capitalized.</p>
+</div>"
+`;
+
+exports[`the plugin options for legacy titles like **Note** > should accept custom class names 1`] = `
+"<h1>Admonitions</h1>
+<blockquote class=\\"ad\\">
+<p><strong class=\\"ad-title1 ad-title2\\">Note</strong>
+test</p>
+</blockquote>"
+`;
+
+exports[`the plugin options for legacy titles like **Note** > should accept custom class names with functions 1`] = `
+"<h1>Admonitions</h1>
+<blockquote class=\\"ad-note\\">
+<p><strong class=\\"ad-note-title1 ad-note-title2\\">Note</strong>
+test</p>
+</blockquote>"
+`;
+
+exports[`the plugin options for legacy titles like **Note** > should accept custom title filter 1`] = `
+"<h1>Admonitions</h1>
+<blockquote class=\\"admonition\\">
+<p><strong class=\\"admonition-title\\">Tips</strong>
+test</p>
+</blockquote>"
+`;
+
+exports[`the plugin options for legacy titles like **Note** > should accept custom title filter with functions 1`] = `
+"<h1>Admonitions</h1>
+<blockquote class=\\"admonition\\">
+<p><strong class=\\"admonition-title\\">tIps</strong>
+test</p>
+</blockquote>"
+`;
+
+exports[`the plugin options for legacy titles like **Note** > should accept data maps to edit data 1`] = `
+"<h1>Admonitions</h1>
+<div class=\\"admonition\\">
+<p><strong class=\\"admonition-title\\">Note</strong>
+test</p>
+</div>"
+`;
+
+exports[`the plugin options for legacy titles like **Note** > should accept title lift 1`] = `
+"<h1>Admonitions</h1>
+<blockquote class=\\"admonition\\">
+<p><strong class=\\"admonition-title\\">Note</strong></p>
+<p>test</p>
+</blockquote>"
+`;
+
+exports[`the plugin options for legacy titles like **Note** > should accept title lift with custom whitespace handling 1`] = `
+"<h1>Admonitions</h1>
+<blockquote class=\\"admonition\\">
+<p><strong class=\\"admonition-title\\">Note</strong></p>
+<p>atest</p>
+</blockquote>"
+`;
+
+exports[`the plugin options for legacy titles like **Note** > should accept title lift with other whitespaces 1`] = `
+"<h1>Admonitions</h1>
+<blockquote class=\\"admonition\\">
+<p><strong class=\\"admonition-title\\">Note</strong></p>
+<p>test</p>
+</blockquote>"
+`;
+
+exports[`the plugin options for legacy titles like **Note** > should accept title text map to customize title text 1`] = `
+"<h1>Admonitions</h1>
+<blockquote class=\\"admonition\\">
+<p><strong class=\\"admonition-title\\">OKOK</strong>
+test</p>
+</blockquote>"
+`;
+
+exports[`the plugin options for legacy titles like **Note** > should accept title unwrap 1`] = `
+"<h1>Admonitions</h1>
+<blockquote class=\\"admonition\\">
+<p class=\\"admonition-title\\">Note</p>
+<p>test</p>
+</blockquote>"
+`;

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -23,6 +23,8 @@ function defineCase(
 
     const html = String(await processor.process(options.input))
     await options.assertions(html)
+
+    expect(html).toMatchSnapshot()
   })
 }
 

--- a/test/legacyTitle.spec.ts
+++ b/test/legacyTitle.spec.ts
@@ -10,46 +10,58 @@ import remarkRehype from 'remark-rehype'
 import rehypeStringify from 'rehype-stringify'
 import plugin, { ConfigForLegacyTitle as Config, mkdocsConfigForLegacyTitle as mkdocsConfig } from '../src/index.js'
 
-async function mdToHtml(md: string, options?: Partial<Config>) {
-  const optionsForLegacyTitle = { ...options, legacyTitle: true }
-  return String(
-    await remark()
+function defineCase(
+  name: string,
+  options: {
+    input: string
+    assertions: (html: string) => Promise<void> | void
+    config?: Partial<Config>
+  }
+) {
+  it(name, async function () {
+    const processor = remark()
       .use(remarkParse)
-      .use(plugin, optionsForLegacyTitle)
+      .use(plugin, { ...options.config, legacyTitle: true })
       .use(remarkRehype)
       .use(rehypeStringify)
-      .process(md)
-  )
+
+    const html = String(await processor.process(options.input))
+    await options.assertions(html)
+  })
 }
 
 describe('GitHub beta blockquote-based admonitions with legacy titles like **Note**', function () {
-  it('should transform', async function () {
-    const html = await mdToHtml(`\
+  defineCase('should transform', {
+    input: `\
 # Admonitions
 > **Note**
 > test
-`)
-    const elem = selectOne(
-      'blockquote.admonition > p:first-child > strong.admonition-title:first-child',
-      parseDocument(html)
-    )
-    expect(elem).to.have.nested.property('firstChild.data', 'Note')
+`,
+    assertions(html) {
+      const elem = selectOne(
+        'blockquote.admonition > p:first-child > strong.admonition-title:first-child',
+        parseDocument(html)
+      )
+      expect(elem).to.have.nested.property('firstChild.data', 'Note')
+    },
   })
 
-  it('should transform when single line', async function () {
-    const html = await mdToHtml(`\
+  defineCase('should transform when single line', {
+    input: `\
 # Admonitions
 > **Note** test
-`)
-    const elem = selectOne(
-      'blockquote.admonition > p:first-child > strong.admonition-title:first-child',
-      parseDocument(html)
-    )
-    expect(elem).to.have.nested.property('firstChild.data', 'Note')
+`,
+    assertions(html) {
+      const elem = selectOne(
+        'blockquote.admonition > p:first-child > strong.admonition-title:first-child',
+        parseDocument(html)
+      )
+      expect(elem).to.have.nested.property('firstChild.data', 'Note')
+    },
   })
 
-  it('should transform with nested ones', async function () {
-    const html = await mdToHtml(`\
+  defineCase('should transform with nested ones', {
+    input: `\
 # Admonitions
 > **Note**
 > test
@@ -59,250 +71,257 @@ describe('GitHub beta blockquote-based admonitions with legacy titles like **Not
 > >
 > > > **Warning**
 > > > test
-`)
-    const elem = selectOne(
-      'blockquote.admonition > blockquote.admonition > blockquote.admonition > p:first-child > strong.admonition-title:first-child',
-      parseDocument(html)
-    )
-    expect(elem).to.have.nested.property('firstChild.data', 'Warning')
+`,
+    assertions(html) {
+      const elem = selectOne(
+        'blockquote.admonition > blockquote.admonition > blockquote.admonition > p:first-child > strong.admonition-title:first-child',
+        parseDocument(html)
+      )
+      expect(elem).to.have.nested.property('firstChild.data', 'Warning')
+    },
   })
 
-  it('should not transform when title is not strong', async function () {
-    const html = await mdToHtml(`\
+  defineCase('should not transform when title is not strong', {
+    input: `\
 # Admonitions
 > *Note*
 > test
-`)
-    const elem = selectOne(
-      'blockquote.admonition > p:first-child > strong.admonition-title:first-child',
-      parseDocument(html)
-    )
-    expect(elem).to.be.null
+`,
+    assertions(html) {
+      const elem = selectOne(
+        'blockquote.admonition > p:first-child > strong.admonition-title:first-child',
+        parseDocument(html)
+      )
+      expect(elem).to.be.null
+    },
   })
 })
 
 describe('the plugin options for legacy titles like **Note**', function () {
-  it('should accept custom class names', async function () {
-    const html = await mdToHtml(
-      `\
+  defineCase('should accept custom class names', {
+    input: `\
 # Admonitions
 > **Note**
 > test
 `,
-      {
-        classNameMaps: {
-          block: 'ad',
-          title: ['ad-title1', 'ad-title2'],
-        },
-      }
-    )
-    const elem = selectOne(
-      'blockquote.ad > p:first-child > strong.ad-title1.ad-title2:first-child',
-      parseDocument(html)
-    )
-    expect(elem).to.have.nested.property('firstChild.data', 'Note')
+    config: {
+      classNameMaps: {
+        block: 'ad',
+        title: ['ad-title1', 'ad-title2'],
+      },
+    },
+    assertions(html) {
+      const elem = selectOne(
+        'blockquote.ad > p:first-child > strong.ad-title1.ad-title2:first-child',
+        parseDocument(html)
+      )
+      expect(elem).to.have.nested.property('firstChild.data', 'Note')
+    },
   })
 
-  it('should accept custom class names with functions', async function () {
-    const html = await mdToHtml(
-      `\
+  defineCase('should accept custom class names with functions', {
+    input: `\
 # Admonitions
 > **Note**
 > test
 `,
-      {
-        classNameMaps: {
-          block: (title) => `ad-${title.toLowerCase()}`,
-          title: (title) => [`ad-${title.toLowerCase()}-title1`, `ad-${title.toLowerCase()}-title2`],
-        },
-      }
-    )
-    const elem = selectOne(
-      'blockquote.ad-note > p:first-child > strong.ad-note-title1.ad-note-title2:first-child',
-      parseDocument(html)
-    )
-    expect(elem).to.have.nested.property('firstChild.data', 'Note')
+    config: {
+      classNameMaps: {
+        block: (title) => `ad-${title.toLowerCase()}`,
+        title: (title) => [`ad-${title.toLowerCase()}-title1`, `ad-${title.toLowerCase()}-title2`],
+      },
+    },
+    assertions(html) {
+      const elem = selectOne(
+        'blockquote.ad-note > p:first-child > strong.ad-note-title1.ad-note-title2:first-child',
+        parseDocument(html)
+      )
+      expect(elem).to.have.nested.property('firstChild.data', 'Note')
+    },
   })
 
-  it('should accept custom title filter', async function () {
-    const html = await mdToHtml(
-      `\
+  defineCase('should accept custom title filter', {
+    input: `\
 # Admonitions
 > **Tips**
 > test
 `,
-      {
-        titleFilter: ['Tips', 'Hints'],
-      }
-    )
-    const elem = selectOne(
-      'blockquote.admonition > p:first-child > strong.admonition-title:first-child',
-      parseDocument(html)
-    )
-    expect(elem).to.have.nested.property('firstChild.data', 'Tips')
+    config: {
+      titleFilter: ['Tips', 'Hints'],
+    },
+    assertions(html) {
+      const elem = selectOne(
+        'blockquote.admonition > p:first-child > strong.admonition-title:first-child',
+        parseDocument(html)
+      )
+      expect(elem).to.have.nested.property('firstChild.data', 'Tips')
+    },
   })
 
-  it('should accept custom title filter with functions', async function () {
-    const html = await mdToHtml(
-      `\
+  defineCase('should accept custom title filter with functions', {
+    input: `\
 # Admonitions
 > **tIps**
 > test
 `,
-      {
-        titleFilter: (title) => title.substring(0, 3) == 'tIp',
-      }
-    )
-    const elem = selectOne(
-      'blockquote.admonition > p:first-child > strong.admonition-title:first-child',
-      parseDocument(html)
-    )
-    expect(elem).to.have.nested.property('firstChild.data', 'tIps')
+    config: {
+      titleFilter: (title) => title.substring(0, 3) == 'tIp',
+    },
+    assertions(html) {
+      const elem = selectOne(
+        'blockquote.admonition > p:first-child > strong.admonition-title:first-child',
+        parseDocument(html)
+      )
+      expect(elem).to.have.nested.property('firstChild.data', 'tIps')
+    },
   })
 
-  it('should accept title lift', async function () {
-    const html = await mdToHtml(
-      `\
+  defineCase('should accept title lift', {
+    input: `\
 # Admonitions
 > **Note**
 > test
 `,
-      {
-        titleLift: true,
-      }
-    )
-    const elem = selectOne(
-      'blockquote.admonition > p:first-child > strong.admonition-title:only-child',
-      parseDocument(html)
-    )
-    expect(elem).to.have.nested.property('firstChild.data', 'Note')
+    config: {
+      titleLift: true,
+    },
+    assertions(html) {
+      const elem = selectOne(
+        'blockquote.admonition > p:first-child > strong.admonition-title:only-child',
+        parseDocument(html)
+      )
+      expect(elem).to.have.nested.property('firstChild.data', 'Note')
+    },
   })
 
-  it('should accept title lift with other whitespaces', async function () {
-    const html = await mdToHtml(
-      `\
+  defineCase('should accept title lift with other whitespaces', {
+    input: `\
 # Admonitions
 > **Note** \t
 > test
 `,
-      {
-        titleLift: true,
-      }
-    )
-    const doc = parseDocument(html)
-    const titleElem = selectOne('blockquote.admonition > p:first-child > strong.admonition-title:only-child', doc)
-    expect(titleElem).to.have.nested.property('firstChild.data', 'Note')
-    const textElem = selectOne('blockquote.admonition > p:nth-child(2)', doc)
-    expect(textElem)
-      .to.have.nested.property('firstChild.data')
-      .and.to.satisfy((data: string) => data.startsWith('test'))
+    config: {
+      titleLift: true,
+    },
+    assertions(html) {
+      const doc = parseDocument(html)
+      const titleElem = selectOne('blockquote.admonition > p:first-child > strong.admonition-title:only-child', doc)
+      expect(titleElem).to.have.nested.property('firstChild.data', 'Note')
+      const textElem = selectOne('blockquote.admonition > p:nth-child(2)', doc)
+      expect(textElem)
+        .to.have.nested.property('firstChild.data')
+        .and.to.satisfy((data: string) => data.startsWith('test'))
+    },
   })
 
-  it('should accept title lift with custom whitespace handling', async function () {
-    const html = await mdToHtml(
-      `\
+  defineCase('should accept title lift with custom whitespace handling', {
+    input: `\
 # Admonitions
 > **Note**
 > test
 `,
-      {
-        titleLift: true,
-        titleLiftWhitespaces: () => 'a',
-      }
-    )
-    const doc = parseDocument(html)
-    const titleElem = selectOne('blockquote.admonition > p:first-child > strong.admonition-title:only-child', doc)
-    expect(titleElem).to.have.nested.property('firstChild.data', 'Note')
-    const textElem = selectOne('blockquote.admonition > p:nth-child(2)', doc)
-    expect(textElem)
-      .to.have.nested.property('firstChild.data')
-      .and.to.satisfy((data: string) => data.startsWith('atest'))
+    config: {
+      titleLift: true,
+      titleLiftWhitespaces: () => 'a',
+    },
+    assertions(html) {
+      const doc = parseDocument(html)
+      const titleElem = selectOne('blockquote.admonition > p:first-child > strong.admonition-title:only-child', doc)
+      expect(titleElem).to.have.nested.property('firstChild.data', 'Note')
+      const textElem = selectOne('blockquote.admonition > p:nth-child(2)', doc)
+      expect(textElem)
+        .to.have.nested.property('firstChild.data')
+        .and.to.satisfy((data: string) => data.startsWith('atest'))
+    },
   })
 
-  it('should accept title unwrap', async function () {
-    const html = await mdToHtml(
-      `\
+  defineCase('should accept title unwrap', {
+    input: `\
 # Admonitions
 > **Note**
 > test
 `,
-      {
-        titleLift: true,
-        titleUnwrap: true,
-      }
-    )
-    const elem = selectOne('blockquote.admonition > p.admonition-title:first-child', parseDocument(html))
-    expect(elem).to.have.nested.property('firstChild.data', 'Note')
+    config: {
+      titleLift: true,
+      titleUnwrap: true,
+    },
+    assertions(html) {
+      const elem = selectOne('blockquote.admonition > p.admonition-title:first-child', parseDocument(html))
+      expect(elem).to.have.nested.property('firstChild.data', 'Note')
+    },
   })
 
-  it('should accept title text map to customize title text', async function () {
-    const html = await mdToHtml(
-      `\
+  defineCase('should accept title text map to customize title text', {
+    input: `\
 # Admonitions
 > **Note:OKOK**
 > test
 `,
-      {
-        titleFilter: (title) => title.startsWith('Note:'),
-        titleTextMap: (title) => {
-          const titleSplit = title.split(':')
-          return { displayTitle: titleSplit[1], checkedTitle: titleSplit[0] }
-        },
-      }
-    )
-    const elem = selectOne(
-      'blockquote.admonition > p:first-child > strong.admonition-title:first-child',
-      parseDocument(html)
-    )
-    expect(elem).to.have.nested.property('firstChild.data', 'OKOK')
+    config: {
+      titleFilter: (title) => title.startsWith('Note:'),
+      titleTextMap: (title) => {
+        const titleSplit = title.split(':')
+        return { displayTitle: titleSplit[1], checkedTitle: titleSplit[0] }
+      },
+    },
+    assertions(html) {
+      const elem = selectOne(
+        'blockquote.admonition > p:first-child > strong.admonition-title:first-child',
+        parseDocument(html)
+      )
+      expect(elem).to.have.nested.property('firstChild.data', 'OKOK')
+    },
   })
 
-  it('should accept data maps to edit data', async function () {
-    const html = await mdToHtml(
-      `\
+  defineCase('should accept data maps to edit data', {
+    input: `\
 # Admonitions
 > **Note**
 > test
 `,
-      {
-        dataMaps: {
-          block: (data) => ({ ...data, hName: 'div' }),
-          title: (data) => data,
-        },
-      }
-    )
-    const elem = selectOne('div.admonition > p:first-child > strong.admonition-title:first-child', parseDocument(html))
-    expect(elem).to.have.nested.property('firstChild.data', 'Note')
+    config: {
+      dataMaps: {
+        block: (data) => ({ ...data, hName: 'div' }),
+        title: (data) => data,
+      },
+    },
+    assertions(html) {
+      const elem = selectOne(
+        'div.admonition > p:first-child > strong.admonition-title:first-child',
+        parseDocument(html)
+      )
+      expect(elem).to.have.nested.property('firstChild.data', 'Note')
+    },
   })
 })
 
 describe('MkDocs admonition HTML options for legacy titles like **Note**', function () {
-  it('should transform', async function () {
-    const html = await mdToHtml(
-      `\
+  defineCase('should transform', {
+    input: `\
 # Admonitions
 > **note danger "Don't try this at home"**
 > You should note that the title will be automatically capitalized.
 `,
-      mkdocsConfig
-    )
-    const elem = selectOne('div.admonition.note.danger > p.admonition-title:first-child', parseDocument(html))
-    expect(elem).to.have.nested.property('firstChild.data', "Don't try this at home")
+    config: mkdocsConfig,
+    assertions(html) {
+      const elem = selectOne('div.admonition.note.danger > p.admonition-title:first-child', parseDocument(html))
+      expect(elem).to.have.nested.property('firstChild.data', "Don't try this at home")
+    },
   })
 
-  it('should transform with custom types', async function () {
-    const html = await mdToHtml(
-      `\
+  defineCase('should transform with custom types', {
+    input: `\
 # Admonitions
 > **admonition: guess "Don't try this at home"**
 > You should note that the title will be automatically capitalized.
 `,
-      mkdocsConfig
-    )
-    const doc = parseDocument(html)
-    const elem = selectOne('div.admonition.guess > p.admonition-title:first-child', doc)
-    expect(elem).to.have.nested.property('firstChild.data', "Don't try this at home")
-    const elemUnexpected = selectOne('div.admonition.admonition\\:', doc)
-    expect(elemUnexpected).to.be.null
+    config: mkdocsConfig,
+    assertions(html) {
+      const doc = parseDocument(html)
+      const elem = selectOne('div.admonition.guess > p.admonition-title:first-child', doc)
+      expect(elem).to.have.nested.property('firstChild.data', "Don't try this at home")
+      const elemUnexpected = selectOne('div.admonition.admonition\\:', doc)
+      expect(elemUnexpected).to.be.null
+    },
   })
 })

--- a/test/legacyTitle.spec.ts
+++ b/test/legacyTitle.spec.ts
@@ -27,6 +27,8 @@ function defineCase(
 
     const html = String(await processor.process(options.input))
     await options.assertions(html)
+
+    expect(html).toMatchSnapshot()
   })
 }
 


### PR DESCRIPTION
Moving all test cases to `defineCase` helper, which centralize the test case definition and remove some boilerplate.

All cases are now test with snapshot as well.