### PR TITLE
Add support for carriage return after admonition title

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,7 @@ dist
 # IDE
 .idea/
 .vscode/
+
+# macOS
+
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -134,5 +134,4 @@ dist
 .vscode/
 
 # macOS
-
 .DS_Store

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,12 +55,13 @@ const handleNode =
       // So we just need to addtionally check if the following one is a block.
       // The legacy title variant is not affected since it checks an inline and does not case the newline.
 
-      // No addtional inlines can exist in this paragraph for the title
+      // No addtional inlines can exist in this paragraph for the title...
       if (paragraph.children.length > 1) {
-        // Carriage returns are allowed by GitHub flavored Markdown.
-        // It makes a more coherent rendering in environments were admonitions aren't supported.
-        // When they are, we must strip the unnecessary `<br />` prepended in the first `<p>`.
+        // Unless it is an inline break, which can be transformed to from 2 spaces with a newline.
         if (paragraph.children.at(1)?.type == 'break') {
+          // When it is, we actually have already found the line break required by GitHub.
+          // So we just strip the additional `<br>` element.
+          // The title element will be removed later.
           paragraph.children.splice(1, 1)
         } else {
           return

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ const handleNode =
         // Carriage returns are allowed by GitHub flavored Markdown.
         // It makes a more coherent rendering in environments were admonitions aren't supported.
         // When they are, we must strip the unnecessary `<br />` prepended in the first `<p>`.
-        if (paragraph.children.at(1)?.type === 'break') {
+        if (paragraph.children.at(1)?.type == 'break') {
           paragraph.children.splice(1, 1)
         } else {
           return

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,17 @@ const handleNode =
       // The legacy title variant is not affected since it checks an inline and does not case the newline.
 
       // No addtional inlines can exist in this paragraph for the title
-      if (paragraph.children.length > 1) return
+      if (paragraph.children.length > 1) {
+        // Carriage returns are allowed by GitHub flavored Markdown.
+        // It makes a more coherent rendering in environments were admonitions aren't supported.
+        // When they are, we must strip the unnecessary `<br />` prepended in the first `<p>`.
+        if (paragraph.children.at(1)?.type === 'break') {
+          paragraph.children.splice(1, 1)
+        } else {
+          return
+        }
+      }
+
       // Considering the reason why the paragraph ends here, the following one should be a children of the blockquote, which means it is always a block.
       // So no more check is required.
 

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -47,6 +47,14 @@ exports[`GitHub beta blockquote-based admonitions with titles like [!NOTE] > sho
 </div>"
 `;
 
+exports[`GitHub beta blockquote-based admonitions with titles like [!NOTE] > should transform when admonition title has 2 trailing spaces (carriage return) from issue #12 1`] = `
+"<h1>Admonitions</h1>
+<div class="admonition admonition--warning">
+<p class="admonition-title admonition-title--warning">Warning</p>
+<p>Critical content demanding immediate user attention due to potential risks.</p>
+</div>"
+`;
+
 exports[`GitHub beta blockquote-based admonitions with titles like [!NOTE] > should transform when title has 2 trailing spaces from issue #12 1`] = `
 "<h1>Admonitions</h1>
 <div class="admonition admonition--warning">
@@ -118,6 +126,14 @@ exports[`MkDocs admonition HTML options for titles like [!NOTE] > should transfo
 <div class="admonition guess">
 <p class="admonition-title">Don't try this at home</p>
 <p>You should note that the title will be automatically capitalized.</p>
+</div>"
+`;
+
+exports[`should transform when admonition title has 2 trailing spaces (carriage return) from issue #12 1`] = `
+"<h1>Admonitions</h1>
+<div class="admonition admonition--warning">
+<p class="admonition-title admonition-title--warning">Warning</p>
+<p>Critical content demanding immediate user attention due to potential risks.</p>
 </div>"
 `;
 

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -47,14 +47,6 @@ exports[`GitHub beta blockquote-based admonitions with titles like [!NOTE] > sho
 </div>"
 `;
 
-exports[`GitHub beta blockquote-based admonitions with titles like [!NOTE] > should transform when admonition title has 2 trailing spaces (carriage return) from issue #12 1`] = `
-"<h1>Admonitions</h1>
-<div class="admonition admonition--warning">
-<p class="admonition-title admonition-title--warning">Warning</p>
-<p>Critical content demanding immediate user attention due to potential risks.</p>
-</div>"
-`;
-
 exports[`GitHub beta blockquote-based admonitions with titles like [!NOTE] > should transform when title has 2 trailing spaces from issue #12 1`] = `
 "<h1>Admonitions</h1>
 <div class="admonition admonition--warning">
@@ -126,14 +118,6 @@ exports[`MkDocs admonition HTML options for titles like [!NOTE] > should transfo
 <div class="admonition guess">
 <p class="admonition-title">Don't try this at home</p>
 <p>You should note that the title will be automatically capitalized.</p>
-</div>"
-`;
-
-exports[`should transform when admonition title has 2 trailing spaces (carriage return) from issue #12 1`] = `
-"<h1>Admonitions</h1>
-<div class="admonition admonition--warning">
-<p class="admonition-title admonition-title--warning">Warning</p>
-<p>Critical content demanding immediate user attention due to potential risks.</p>
 </div>"
 `;
 

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -47,6 +47,14 @@ exports[`GitHub beta blockquote-based admonitions with titles like [!NOTE] > sho
 </div>"
 `;
 
+exports[`GitHub beta blockquote-based admonitions with titles like [!NOTE] > should transform when title has 2 trailing spaces from issue #12 1`] = `
+"<h1>Admonitions</h1>
+<div class="admonition admonition--warning">
+<p class="admonition-title admonition-title--warning">Warning</p>
+<p>Critical content demanding immediate user attention due to potential risks.</p>
+</div>"
+`;
+
 exports[`GitHub beta blockquote-based admonitions with titles like [!NOTE] > should transform with nested ones 1`] = `
 "<h1>Admonitions</h1>
 <div class="admonition">

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -161,10 +161,13 @@ describe('GitHub beta blockquote-based admonitions with titles like [!NOTE]', fu
     },
   })
 
-  defineCase('should transform when title has 2 trailing spaces from issue #12', {
+  defineCase('should transform when admonition title has 2 trailing spaces (carriage return) from issue #12', {
     input:
-      '# Admonitions  \n' +
-      '> [!WARNING]\n' +
+      '# Admonitions\n' +
+      // So that the title isn't put inline with the forecoming text,
+      // when no GFM admonitions are available.
+      // ----------vv
+      '> [!WARNING]  \n' +
       '> Critical content demanding immediate user attention due to potential risks.\n',
     config: {
       classNameMaps: {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -161,7 +161,7 @@ describe('GitHub beta blockquote-based admonitions with titles like [!NOTE]', fu
     },
   })
 
-  defineCase('should transform when admonition title has 2 trailing spaces (carriage return) from issue #12', {
+  defineCase('should transform when title has 2 trailing spaces from issue #12', {
     input:
       '# Admonitions\n' +
       // So that the title isn't put inline with the forecoming text,

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -160,6 +160,34 @@ describe('GitHub beta blockquote-based admonitions with titles like [!NOTE]', fu
       expect(elems[4]).to.have.nested.property('firstChild.data', 'CAUTION')
     },
   })
+
+  defineCase('should transform when title has 2 trailing spaces from issue #12', {
+    input:
+      '# Admonitions  \n' +
+      '> [!WARNING]\n' +
+      '> Critical content demanding immediate user attention due to potential risks.\n',
+    config: {
+      classNameMaps: {
+        block: (title: string) => `admonition admonition--${title.toLowerCase()}`,
+        title: (title: string) => `admonition-title admonition-title--${title.toLowerCase()}`,
+      },
+
+      titleTextMap: (title: string) => {
+        // Removes `![]`
+        let displayTitle = title.slice(2, -1)
+        // Capitalize
+        displayTitle = `${displayTitle.at(0)}${displayTitle.substring(1).toLowerCase()}`
+        return {
+          displayTitle,
+          checkedTitle: displayTitle,
+        }
+      },
+    },
+    assertions(html) {
+      const elem = selectOne('div.admonition > p.admonition-title:first-child', parseDocument(html))
+      expect(elem).to.have.nested.property('firstChild.data', 'Warning')
+    },
+  })
 })
 
 describe('the plugin options for titles like [!NOTE]', function () {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -166,6 +166,7 @@ describe('GitHub beta blockquote-based admonitions with titles like [!NOTE]', fu
       '# Admonitions\n' +
       // So that the title isn't put inline with the forecoming text,
       // when no GFM admonitions are available.
+      // These 2 spaces with the newline are transformed into an inline break.
       // ----------vv
       '> [!WARNING]  \n' +
       '> Critical content demanding immediate user attention due to potential risks.\n',


### PR DESCRIPTION
With spaces for carriage return:

`-------vv`
> [!TIP]  
> Recommended VS Code extensions

Without spaces for carriage return:

> [!TIP]
> Recommended VS Code extensions

GitHub renders the same.

For envs. without admonitions this allow to render like this:

> {!FAKE_ADMONITION}
> My paragram

Instead of this:

> {!FAKE_ADMONITION} My paragram

The first one looks more like GitHub layout, which is the ultimate goal of this PR.